### PR TITLE
Update  regex to not match the empty string

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -320,7 +320,7 @@ export const getFilteredURL = (url, connected_data_parameters = []) => {
   if (!connected_data_parameters?.length) return url;
   let decodedURL = decodeURIComponent(url);
   //lookahead assertion to ensure that at least one character exists between '<<' and '>>';
-  const queries = decodedURL.match(/<<(?=.*?>>).*?>>/g); //safari: don't use lookbehind
+  const queries = decodedURL.match(/<<(?!\s*>>)[^>]*>>/g); //safari: don't use lookbehind
   if (!queries?.length) return url;
 
   const filteredQueries = queries.map((query) =>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -320,7 +320,7 @@ export const getFilteredURL = (url, connected_data_parameters = []) => {
   if (!connected_data_parameters?.length) return url;
   let decodedURL = decodeURIComponent(url);
   //lookahead assertion to ensure that at least one character exists between '<<' and '>>';
-  const queries = decodedURL.match(/<<(?!\s*>>)[^>]*>>/g); //safari: don't use lookbehind
+  const queries = decodedURL.match(/^<<(?!\s*>>)[^<>]*>>$/g); //safari: don't use lookbehind
   if (!queries?.length) return url;
 
   const filteredQueries = queries.map((query) =>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -319,7 +319,8 @@ export function useOnScreen(ref, rootMargin = '0px') {
 export const getFilteredURL = (url, connected_data_parameters = []) => {
   if (!connected_data_parameters?.length) return url;
   let decodedURL = decodeURIComponent(url);
-  const queries = decodedURL.match(/(<<)(.*?)*>>/g); //safari: don't use lookbehind
+  //lookahead assertion to ensure that at least one character exists between '<<' and '>>';
+  const queries = decodedURL.match(/<<(?=.*?>>).*?>>/g); //safari: don't use lookbehind
   if (!queries?.length) return url;
 
   const filteredQueries = queries.map((query) =>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -320,11 +320,11 @@ export const getFilteredURL = (url, connected_data_parameters = []) => {
   if (!connected_data_parameters?.length) return url;
   let decodedURL = decodeURIComponent(url);
   //lookahead assertion to ensure that at least one character exists between '<<' and '>>';
-  const queries = decodedURL.match(/^<<(?!\s*>>)[^<>]*>>$/g); //safari: don't use lookbehind
+  const queries = decodedURL.match(/^<<(?!\s*>>)[^<>]*>>/g); //safari: don't use lookbehind
   if (!queries?.length) return url;
 
   const filteredQueries = queries.map((query) =>
-    query.replace('<<', '').replace('>>', ''),
+    query.trim().replace('<<', '').replace('>>', ''),
   );
 
   const keys = connected_data_parameters.map((param) => param.i);


### PR DESCRIPTION
[Fix issue](https://sonarqube.eea.europa.eu/project/issues?resolved=false&types=BUG&id=volto-datablocks-develop&open=AYBwK4kjFnqPak80yLoD): decodedURL.match(/(<<)(.*?)*>>/g) - Rework this part of the regex to not match the empty string.