### PR TITLE
Fix when connector data uses lowercase for columns; Add filter_connec…

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -96,9 +96,9 @@ function getCaseInsensitiveColumnName(providerData, columnName) {
   const key = Object.keys(providerData).includes(columnName)
     ? columnName
     : Object.keys(providerData)
-        .map((s) => s.toLowerCase())
-        .includes(columnName.toLowerCase())
-    ? columnName.toLowerCase()
+        .map((s) => s?.toLowerCase())
+        .includes(columnName?.toLowerCase())
+    ? columnName?.toLowerCase()
     : null;
   return key;
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -92,40 +92,47 @@ export function getDataQuery({
   return query;
 }
 
+function getCaseInsensitiveColumnName(providerData, columnName) {
+  const key = Object.keys(providerData).includes(columnName)
+    ? columnName
+    : Object.keys(providerData)
+        .map((s) => s.toLowerCase())
+        .includes(columnName.toLowerCase())
+    ? columnName.toLowerCase()
+    : null;
+  return key;
+}
+
 /*
  * refreshes chart data using data from provider
  * this is similar to mixProviderData from ConnectedChart, but it doesn't apply
- * transformation
+ * transformation.
  */
 export function updateChartDataFromProvider(chartData, providerData) {
   if (!providerData) return chartData;
 
-  const providerDataColumns = Object.keys(providerData);
-
   const res = chartData.map((trace) => {
     const newTrace = { ...(trace || {}) };
-    Object.keys(trace).forEach((tk) => {
-      const originalColumn = tk.replace(/src$/, '');
+    Object.keys(trace).forEach((traceKey) => {
+      const originalColumnName = traceKey.replace(/src$/, '');
       if (
-        tk.endsWith('src') &&
-        Object.keys(trace).includes(originalColumn) &&
-        typeof trace[tk] === 'string' &&
-        providerDataColumns.includes(trace[tk])
+        traceKey.endsWith('src') &&
+        Object.keys(trace).includes(originalColumnName) &&
+        typeof trace[traceKey] === 'string'
       ) {
-        let values = providerData[trace[tk]];
-
-        newTrace[originalColumn] = values;
+        const providerColumnName = getCaseInsensitiveColumnName(
+          providerData,
+          trace[traceKey],
+        );
+        newTrace[originalColumnName] = providerData[providerColumnName];
       }
     });
     newTrace.transforms = (trace.transforms || []).map((transform) => {
       // Sometimes the provider columns change to lower/uppercase, so let's handle that
-      const key = Object.keys(providerData).includes(transform.targetsrc)
-        ? transform.targetsrc
-        : Object.keys(providerData)
-            .map((s) => s.toLowerCase())
-            .includes(transform.targetsrc.toLowerCase())
-        ? transform.targetsrc.toLowerCase()
-        : null;
+      const key = getCaseInsensitiveColumnName(
+        providerData,
+        transform.targetsrc,
+      );
       if (key === null) {
         // eslint-disable-next-line no-console
         console.warn(

--- a/src/hocs/connectToProviderData.js
+++ b/src/hocs/connectToProviderData.js
@@ -45,6 +45,7 @@ export function connectToProviderData(getConfig = () => ({})) {
       data_providers: state.data_providers,
     }))(
       withRouter((props) => {
+        // console.log('props', props);
         const dispatch = useDispatch();
         const params = useParams();
         const config = useMemo(() => getConfig(props), [props]);
@@ -71,7 +72,12 @@ export function connectToProviderData(getConfig = () => ({})) {
           [props, pagination, state.extraQuery, state.extraConditions],
         );
         const data_query = useMemo(
-          () => getDataQuery({ ...props, params, pagination, provider_url }),
+          () =>
+            // some blocks need unfiltered access to the data, for example
+            // a chart that shows data for all the countries
+            props.data?.filter_connector_data_at_source === false
+              ? []
+              : getDataQuery({ ...props, params, pagination, provider_url }),
           [props, params, pagination, provider_url],
         );
 


### PR DESCRIPTION
…tor_data_at_source field; this allows charts to have access to all the data in the provider, as the @connector-data endpoint now gets passed criteria in the POST and filter the data server-side